### PR TITLE
Add LRU cache strategy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,11 +33,9 @@ var (
 		Short:   "media server for lbrytv",
 		Version: version.FullName(),
 		Run: func(cmd *cobra.Command, args []string) {
-			var logLevel logrus.Level
+			logLevel := logrus.InfoLevel
 			if verboseOutput {
 				logLevel = logrus.DebugLevel
-			} else {
-				logLevel = logrus.InfoLevel
 			}
 			logger.ConfigureDefaults(logLevel)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,7 @@ var (
 	cacheSize        string
 	enablePrefetch   bool
 	enableProfile    bool
-	useQuic    bool
+	useQuic          bool
 	reflectorAddress string
 	reflectorTimeout int
 	lbrynetAddress   string
@@ -42,18 +42,21 @@ var (
 				Logger.Fatalf("error: %v\n", err)
 			}
 
+			var cache player.ChunkCache
+			// cache, err := InitLRUCache(&LRUCacheOpts{Path: path.Join(os.TempDir(), "blob_cache"), Size: uint64(opts.CacheSize)})
+			if cacheSizeBytes > 0 {
+				cache, err = player.InitLRUCache(&player.LRUCacheOpts{Path: cachePath, Size: uint64(cacheSizeBytes)})
+				if err != nil {
+					Logger.Fatalf("cannot initialize cache: %v\n", err)
+				}
+			}
 			pOpts := &player.Opts{
-				EnableL2Cache:    true,
-				CacheSize:        cacheSizeBytes,
-				CachePath:        cachePath,
+				LocalCache:       cache,
 				EnablePrefetch:   enablePrefetch,
 				ReflectorAddress: reflectorAddress,
 				ReflectorTimeout: time.Second * time.Duration(reflectorTimeout),
 				LbrynetAddress:   lbrynetAddress,
-				UseQuicProtocol: useQuic,
-			}
-			if pOpts.CacheSize == 0 {
-				pOpts.EnableL2Cache = false
+				UseQuicProtocol:  useQuic,
 			}
 
 			p := player.NewPlayer(pOpts)

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee
 	github.com/dgraph-io/ristretto v0.0.1
 	github.com/getsentry/sentry-go v0.5.1
+	github.com/goburrow/cache v0.1.0 // indirect
 	github.com/gorilla/mux v1.7.3
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/lbryio/lbry.go/v2 v2.4.6
-	github.com/lbryio/reflector.go v1.1.3-0.20200322043846-989265946d7a
+	github.com/lbryio/reflector.go v1.1.3-0.20200403124949-9c1b023de685
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 // indirect
 	github.com/prometheus/client_golang v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee
 	github.com/dgraph-io/ristretto v0.0.1
 	github.com/getsentry/sentry-go v0.5.1
-	github.com/goburrow/cache v0.1.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/lbryio/lbry.go/v2 v2.4.6

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4K
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
+github.com/StackExchange/wmi v0.0.0-20170410192909-ea383cf3ba6e/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -100,11 +101,15 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
+github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-sql-driver/mysql v0.0.0-20180719071942-99ff426eb706/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/goburrow/cache v0.1.0 h1:fLNGLIWhng4Vw3AjbafHou7R3M5wiaz2tMhg6aFkqXM=
+github.com/goburrow/cache v0.1.0/go.mod h1:8oxkfud4hvjO4tNjEKZfEd+LrpDVDlBIauGYsWGEzio=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
@@ -134,6 +139,8 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gops v0.3.7 h1:KtVAagOM0FIq+02DiQrKBTnLhYpWBMowaufcj+W1Exw=
+github.com/google/gops v0.3.7/go.mod h1:bj0cwMmX1X4XIJFTjR99R5sCxNssNJ8HebFNvoQlmgY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f h1:TyqzGm2z1h3AGhjOoRYyeLcW4WlW81MDQkWa+rx/000=
@@ -174,6 +181,8 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -217,10 +226,13 @@ github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVE
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 h1:PJPDf8OUfOK1bb/NeTKd4f1QXZItOX389VN3B6qC8ro=
+github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kataras/golog v0.0.9/go.mod h1:12HJgwBIZFNGL0EJnMRhmvGA0PQGx8VFwrZtM4CqbAk=
 github.com/kataras/iris/v12 v12.0.1/go.mod h1:udK4vLQKkdDqMGJJVd/msuMtN6hpYJhg/lSzuxjhO+U=
 github.com/kataras/neffos v0.0.10/go.mod h1:ZYmJC07hQPW67eKuzlfY7SO3bC0mw83A3j6im82hfqw=
 github.com/kataras/pio v0.0.0-20190103105442-ea782b38602d/go.mod h1:NV88laa9UiiDuX9AhMbDPkGYSPugBOV6yTZB1l2K9Z0=
+github.com/keybase/go-ps v0.0.0-20161005175911-668c8856d999/go.mod h1:hY+WOq6m2FpbvyrI93sMaypsttvaIL5nhVR92dTMUcQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
@@ -244,6 +256,7 @@ github.com/lbryio/errors.go v0.0.0-20180223142025-ad03d3cc6a5c/go.mod h1:muH7wpU
 github.com/lbryio/lbry.go v1.1.1-0.20190825202001-8fa28d3d656f/go.mod h1:JtyI30bU51rm0LZ/po3mQuzf++14OWb6kR/6mMRAmKU=
 github.com/lbryio/lbry.go v1.1.2 h1:Dyxc+glT/rVWJwHfIf7vjlPYYbjzrQz5ARmJd5Hp69c=
 github.com/lbryio/lbry.go v1.1.2/go.mod h1:JtyI30bU51rm0LZ/po3mQuzf++14OWb6kR/6mMRAmKU=
+github.com/lbryio/lbry.go/v2 v2.4.0/go.mod h1:0T0rndOsKQtl18PlFD2ohgX16RCNianUgYB136sAqiE=
 github.com/lbryio/lbry.go/v2 v2.4.5/go.mod h1:if3y+rnBnsZN4aYsWF/kHGpCta8kmLFflqRnMkKlX08=
 github.com/lbryio/lbry.go/v2 v2.4.6 h1:/Wle9uHC1bBckiBUzXo+90IGcQajSql0heWBe0/djzk=
 github.com/lbryio/lbry.go/v2 v2.4.6/go.mod h1:if3y+rnBnsZN4aYsWF/kHGpCta8kmLFflqRnMkKlX08=
@@ -251,10 +264,16 @@ github.com/lbryio/lbryschema.go v0.0.0-20190428231007-c54836bca002/go.mod h1:dAz
 github.com/lbryio/lbryschema.go v0.0.0-20190602173230-6d2f69a36f46 h1:LemfR+rMxhf7nnOrzy2HqS7Me7SZ5gEwOcNFzKC8ySQ=
 github.com/lbryio/lbryschema.go v0.0.0-20190602173230-6d2f69a36f46/go.mod h1:dAzPCBj3CKKWBGYBZxK6tKBP5SCgY2tqd9SnQd/OyKo=
 github.com/lbryio/ozzo-validation v0.0.0-20170323141101-d1008ad1fd04/go.mod h1:fbG/dzobG8r95KzMwckXiLMHfFjZaBRQqC9hPs2XAQ4=
+github.com/lbryio/reflector.go v1.1.2 h1:ElYWInFarYbmcnoWhxmZadDs1KuH4YuM/gmD5LlI4Sk=
+github.com/lbryio/reflector.go v1.1.2/go.mod h1:CdVNupRvDT9D5yFyl8Xl9PeUSy0XRUj+bk4S5FwrOuc=
 github.com/lbryio/reflector.go v1.1.3-0.20200322033701-f54adbb6e5be h1:l5UY7p74Xf9mVzgM4NkFzhGKCXlnJFKZQtbjpybXPiw=
 github.com/lbryio/reflector.go v1.1.3-0.20200322033701-f54adbb6e5be/go.mod h1:uUC0QxPRO/HeCAhfpABRf1NPhwiFjLhhqwhCYaCgpKE=
 github.com/lbryio/reflector.go v1.1.3-0.20200322043846-989265946d7a h1:+RRRVsLjStqhzeUU6yrtISimyQOXuxwJW2OIr8IxVJI=
 github.com/lbryio/reflector.go v1.1.3-0.20200322043846-989265946d7a/go.mod h1:uUC0QxPRO/HeCAhfpABRf1NPhwiFjLhhqwhCYaCgpKE=
+github.com/lbryio/reflector.go v1.1.3-0.20200403124949-9c1b023de685 h1:KyvGiqP7Yuv1jJ7z79x4IiDf6hnTtbYDgViYC/PqZVg=
+github.com/lbryio/reflector.go v1.1.3-0.20200403124949-9c1b023de685/go.mod h1:SFY98o1Zt/bWX+XuL/t4/XU7uWPjZBHRArM4HstTu38=
+github.com/lbryio/reflector.go v1.1.4 h1:XJRH+pSBG5zXmSydk4ai1Y95VBegy+04ek1t3ctFqu0=
+github.com/lbryio/reflector.go v1.1.4/go.mod h1:SFY98o1Zt/bWX+XuL/t4/XU7uWPjZBHRArM4HstTu38=
 github.com/lbryio/types v0.0.0-20190422033210-321fb2abda9c/go.mod h1:CG3wsDv5BiVYQd5i1Jp7wGsaVyjZTJshqXeWMVKsISE=
 github.com/lbryio/types v0.0.0-20191009145016-1bb8107e04f8 h1:jSNW/rK6DQsz7Zh+iv1zR384PeQdHt0gS4hKY17tkuM=
 github.com/lbryio/types v0.0.0-20191009145016-1bb8107e04f8/go.mod h1:CG3wsDv5BiVYQd5i1Jp7wGsaVyjZTJshqXeWMVKsISE=
@@ -370,6 +389,8 @@ github.com/sebdah/goldie v0.0.0-20190531093107-d313ffb52c77/go.mod h1:jXP4hmWywN
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sfreiberg/gotwilio v0.0.0-20180612161623-8fb7259ba8bf/go.mod h1:60PiR0SAnAcYSiwrXB6BaxeqHdXMf172toCosHfV+Yk=
+github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v0.0.0-20180607144847-19e3cb6c2930/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 h1:Gojs/hac/DoYEM7WEICT45+hNWczIeuL5D21e5/HPAw=
@@ -395,6 +416,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v0.0.0-20180722215644-7c4570c3ebeb/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
@@ -444,6 +466,7 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/ybbus/jsonrpc v0.0.0-20180411222309-2a548b7d822d/go.mod h1:XJrh1eMSzdIYFbM08flv0wp5G35eRniyeGut1z+LSiE=
@@ -455,6 +478,7 @@ github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZ
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.1 h1:rsqfU5vBkVknbhUGbAUwQKR2H4ItV8tjJ+6kJX4cxHM=
 go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -505,6 +529,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20171017063910-8dbc5d05d6ed/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -523,6 +548,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191009170203-06d7bd2c5f4f h1:hjzMYz/7Ea1mNKfOnFOfktR0mlA5jqhvywClCMHM/qw=
 golang.org/x/sys v0.0.0-20191009170203-06d7bd2c5f4f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 h1:JA8d3MPx/IToSyXZG/RhwYEtfrKO1Fxrqe8KrkiLXKM=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -595,3 +621,4 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+rsc.io/goversion v1.0.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=

--- a/go.sum
+++ b/go.sum
@@ -104,12 +104,9 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AE
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
-github.com/go-sql-driver/mysql v0.0.0-20180719071942-99ff426eb706/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/goburrow/cache v0.1.0 h1:fLNGLIWhng4Vw3AjbafHou7R3M5wiaz2tMhg6aFkqXM=
-github.com/goburrow/cache v0.1.0/go.mod h1:8oxkfud4hvjO4tNjEKZfEd+LrpDVDlBIauGYsWGEzio=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
@@ -256,7 +253,6 @@ github.com/lbryio/errors.go v0.0.0-20180223142025-ad03d3cc6a5c/go.mod h1:muH7wpU
 github.com/lbryio/lbry.go v1.1.1-0.20190825202001-8fa28d3d656f/go.mod h1:JtyI30bU51rm0LZ/po3mQuzf++14OWb6kR/6mMRAmKU=
 github.com/lbryio/lbry.go v1.1.2 h1:Dyxc+glT/rVWJwHfIf7vjlPYYbjzrQz5ARmJd5Hp69c=
 github.com/lbryio/lbry.go v1.1.2/go.mod h1:JtyI30bU51rm0LZ/po3mQuzf++14OWb6kR/6mMRAmKU=
-github.com/lbryio/lbry.go/v2 v2.4.0/go.mod h1:0T0rndOsKQtl18PlFD2ohgX16RCNianUgYB136sAqiE=
 github.com/lbryio/lbry.go/v2 v2.4.5/go.mod h1:if3y+rnBnsZN4aYsWF/kHGpCta8kmLFflqRnMkKlX08=
 github.com/lbryio/lbry.go/v2 v2.4.6 h1:/Wle9uHC1bBckiBUzXo+90IGcQajSql0heWBe0/djzk=
 github.com/lbryio/lbry.go/v2 v2.4.6/go.mod h1:if3y+rnBnsZN4aYsWF/kHGpCta8kmLFflqRnMkKlX08=
@@ -264,16 +260,8 @@ github.com/lbryio/lbryschema.go v0.0.0-20190428231007-c54836bca002/go.mod h1:dAz
 github.com/lbryio/lbryschema.go v0.0.0-20190602173230-6d2f69a36f46 h1:LemfR+rMxhf7nnOrzy2HqS7Me7SZ5gEwOcNFzKC8ySQ=
 github.com/lbryio/lbryschema.go v0.0.0-20190602173230-6d2f69a36f46/go.mod h1:dAzPCBj3CKKWBGYBZxK6tKBP5SCgY2tqd9SnQd/OyKo=
 github.com/lbryio/ozzo-validation v0.0.0-20170323141101-d1008ad1fd04/go.mod h1:fbG/dzobG8r95KzMwckXiLMHfFjZaBRQqC9hPs2XAQ4=
-github.com/lbryio/reflector.go v1.1.2 h1:ElYWInFarYbmcnoWhxmZadDs1KuH4YuM/gmD5LlI4Sk=
-github.com/lbryio/reflector.go v1.1.2/go.mod h1:CdVNupRvDT9D5yFyl8Xl9PeUSy0XRUj+bk4S5FwrOuc=
-github.com/lbryio/reflector.go v1.1.3-0.20200322033701-f54adbb6e5be h1:l5UY7p74Xf9mVzgM4NkFzhGKCXlnJFKZQtbjpybXPiw=
-github.com/lbryio/reflector.go v1.1.3-0.20200322033701-f54adbb6e5be/go.mod h1:uUC0QxPRO/HeCAhfpABRf1NPhwiFjLhhqwhCYaCgpKE=
-github.com/lbryio/reflector.go v1.1.3-0.20200322043846-989265946d7a h1:+RRRVsLjStqhzeUU6yrtISimyQOXuxwJW2OIr8IxVJI=
-github.com/lbryio/reflector.go v1.1.3-0.20200322043846-989265946d7a/go.mod h1:uUC0QxPRO/HeCAhfpABRf1NPhwiFjLhhqwhCYaCgpKE=
 github.com/lbryio/reflector.go v1.1.3-0.20200403124949-9c1b023de685 h1:KyvGiqP7Yuv1jJ7z79x4IiDf6hnTtbYDgViYC/PqZVg=
 github.com/lbryio/reflector.go v1.1.3-0.20200403124949-9c1b023de685/go.mod h1:SFY98o1Zt/bWX+XuL/t4/XU7uWPjZBHRArM4HstTu38=
-github.com/lbryio/reflector.go v1.1.4 h1:XJRH+pSBG5zXmSydk4ai1Y95VBegy+04ek1t3ctFqu0=
-github.com/lbryio/reflector.go v1.1.4/go.mod h1:SFY98o1Zt/bWX+XuL/t4/XU7uWPjZBHRArM4HstTu38=
 github.com/lbryio/types v0.0.0-20190422033210-321fb2abda9c/go.mod h1:CG3wsDv5BiVYQd5i1Jp7wGsaVyjZTJshqXeWMVKsISE=
 github.com/lbryio/types v0.0.0-20191009145016-1bb8107e04f8 h1:jSNW/rK6DQsz7Zh+iv1zR384PeQdHt0gS4hKY17tkuM=
 github.com/lbryio/types v0.0.0-20191009145016-1bb8107e04f8/go.mod h1:CG3wsDv5BiVYQd5i1Jp7wGsaVyjZTJshqXeWMVKsISE=
@@ -416,7 +404,6 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v0.0.0-20180722215644-7c4570c3ebeb/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,15 +12,25 @@ const (
 )
 
 var (
-	jsonFormatter = logrus.JSONFormatter{DisableTimestamp: true}
-	textFormatter = logrus.TextFormatter{FullTimestamp: true, TimestampFormat: "15:04:05"}
-	Logger        = GetLogger()
+	JsonFormatter = &logrus.JSONFormatter{DisableTimestamp: true}
+	TextFormatter = &logrus.TextFormatter{FullTimestamp: true, TimestampFormat: "15:04:05"}
+	level         = logrus.InfoLevel
+	formatter     = TextFormatter
+	loggers       []*logrus.Logger
 )
+
+func ConfigureDefaults(logLevel logrus.Level) {
+	level = logLevel
+	for _, logger := range loggers {
+		logger.SetLevel(level)
+	}
+}
 
 func GetLogger() *logrus.Logger {
 	logger := logrus.New()
-	logger.SetLevel(logrus.InfoLevel)
-	logger.SetFormatter(&textFormatter)
+	logger.SetLevel(level)
+	logger.SetFormatter(JsonFormatter)
+	loggers = append(loggers, logger)
 	return logger
 }
 

--- a/pkg/logger/sentry.go
+++ b/pkg/logger/sentry.go
@@ -15,6 +15,7 @@ var SentryHandler = sentryhttp.New(sentryhttp.Options{
 })
 
 func ConfigureSentry(release, env string) {
+	l := GetLogger()
 	dsn := os.Getenv("SENTRY_DSN")
 	opts := sentry.ClientOptions{
 		Dsn:              dsn,
@@ -26,15 +27,15 @@ func ConfigureSentry(release, env string) {
 	if env == EnvTest {
 		opts.Transport = TestSentryTransport
 	} else if dsn == "" {
-		Logger.Info("sentry disabled")
+		l.Info("sentry disabled")
 		return
 	}
 
 	err := sentry.Init(opts)
 	if err != nil {
-		Logger.Fatalf("sentry initialization failed: %v", err)
+		l.Fatalf("sentry initialization failed: %v", err)
 	} else {
-		Logger.Info("sentry initialized")
+		l.Info("sentry initialized")
 	}
 }
 

--- a/player/cache.go
+++ b/player/cache.go
@@ -85,7 +85,7 @@ func InitFSCache(opts *FSCacheOpts) (ChunkCache, error) {
 	go func() {
 		for {
 			<-sweepTicker.C
-			c.sweep()
+			c.sweepChunks()
 		}
 	}()
 	go func() {
@@ -98,7 +98,7 @@ func InitFSCache(opts *FSCacheOpts) (ChunkCache, error) {
 	}()
 	go func() {
 		Logger.Infoln("restoring cache in memory...")
-		err := c.reloadCache()
+		err := c.reloadExistingChunks()
 		if err != nil {
 			Logger.Errorf("failed to restore cache in memory: %s", err.Error())
 		} else {
@@ -110,7 +110,7 @@ func InitFSCache(opts *FSCacheOpts) (ChunkCache, error) {
 	return c, nil
 }
 
-func (c *fsCache) reloadCache() error {
+func (c *fsCache) reloadExistingChunks() error {
 	err := filepath.Walk(c.storage.path, func(path string, info os.FileInfo, err error) error {
 		if c.storage.path == path {
 			return nil
@@ -277,7 +277,7 @@ func (c *fsCache) Size() uint64 {
 	return c.rCache.Metrics.CostAdded() - c.rCache.Metrics.CostEvicted()
 }
 
-func (c *fsCache) sweep() {
+func (c *fsCache) sweepChunks() {
 	var removed int
 	err := filepath.Walk(c.storage.path, func(path string, info os.FileInfo, err error) error {
 		if c.storage.path == path {

--- a/player/cache.go
+++ b/player/cache.go
@@ -21,13 +21,13 @@ type ChunkCache interface {
 	Set(string, []byte) (ReadableChunk, error)
 	Remove(string)
 	Size() uint64
-	IsCacheRestored() chan bool
+	WaitForRestore() error
 }
 
 type fsCache struct {
-	storage     *fsStorage
-	rCache      *ristretto.Cache
-	hasRestored chan bool
+	storage  *fsStorage
+	rCache   *ristretto.Cache
+	resError chan error
 }
 
 // FSCacheOpts contains options for filesystem cache. Size is max size in bytes
@@ -78,7 +78,7 @@ func InitFSCache(opts *FSCacheOpts) (ChunkCache, error) {
 		return nil, err
 	}
 
-	c := &fsCache{storage, r, make(chan bool, 1)}
+	c := &fsCache{storage, r, make(chan error, 1)}
 
 	sweepTicker := time.NewTicker(opts.SweepInterval)
 	metricsTicker := time.NewTicker(500 * time.Millisecond)
@@ -101,9 +101,10 @@ func InitFSCache(opts *FSCacheOpts) (ChunkCache, error) {
 		err := c.reloadCache()
 		if err != nil {
 			Logger.Errorf("failed to restore cache in memory: %s", err.Error())
+		} else {
+			Logger.Infoln("done restoring cache in memory")
 		}
-		c.hasRestored <- true
-		Logger.Infoln("done restoring cache in memory")
+		c.resError <- err
 	}()
 
 	return c, nil
@@ -185,10 +186,11 @@ func (c *fsCache) Has(hash string) bool {
 	return ok
 }
 
-// IsCacheRestored returns a channel that can be used to wait for the cache to be restored in memory
-// this channel can only be used once. A second use will block forever.
-func (c *fsCache) IsCacheRestored() chan bool {
-	return c.hasRestored
+// WaitForRestore blocks execution until cache restore is complete and returns the resulting error (if any).
+func (c *fsCache) WaitForRestore() error {
+	err := <-c.resError
+	close(c.resError)
+	return err
 }
 
 // Get returns ReadableChunk if it can be retrieved from the cache by the requested hash

--- a/player/cache_test.go
+++ b/player/cache_test.go
@@ -53,8 +53,9 @@ func TestFSCacheReloadFolder(t *testing.T) {
 	f.Close()
 
 	c, err := InitFSCache(&FSCacheOpts{Path: dir})
-	require.Nil(t, err)
-	<-c.IsCacheRestored()
+	require.NoError(t, err)
+	err = c.WaitForRestore()
+	require.NoError(t, err)
 	// the cache doesn't guarantee that when setting an item it's immediately available. so our only option is to wait
 	waitForCache()
 	isCached := c.Has(blobName)

--- a/player/http_handlers_test.go
+++ b/player/http_handlers_test.go
@@ -127,7 +127,7 @@ func TestHandleHead(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, "video/mp4", response.Header.Get("Content-Type"))
-	assert.Equal(t, "Fri, 17 Nov 2017 17:19:50 GMT", response.Header.Get("Last-Modified"))
+	assert.Equal(t, "Tue, 14 Nov 2017 20:36:33 GMT", response.Header.Get("Last-Modified"))
 	assert.Equal(t, "158433824", response.Header.Get("Content-Length"))
 }
 

--- a/player/lru_cache.go
+++ b/player/lru_cache.go
@@ -1,0 +1,116 @@
+package player
+
+import (
+	"os"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+)
+
+// LRUCacheOpts contains options for a cache. Size is max size in bytes
+type LRUCacheOpts struct {
+	Path          string
+	Size          uint64
+	SweepInterval time.Duration
+}
+
+type lruCache struct {
+	storage *fsStorage
+	lru     *lru.Cache
+}
+
+// InitNGCache initializes a cache for chunks.
+func InitLRUCache(opts *LRUCacheOpts) (ChunkCache, error) {
+	storage, err := initFSStorage(opts.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Size == 0 {
+		opts.Size = defaultMaxCacheSize
+	}
+
+	onEvicted := func(key interface{}, value interface{}) {
+		storage.remove(value)
+	}
+
+	lru, err := lru.NewWithEvict(int(opts.Size/ChunkSize), onEvicted)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &lruCache{storage, lru}
+
+	return c, nil
+}
+
+func (c *lruCache) Set(hash string, body []byte) (ReadableChunk, error) {
+	var numWritten int
+	Logger.Debugf("attempting to cache chunk %v", hash)
+	chunkPath := c.storage.getPath(hash)
+
+	f, err := os.OpenFile(chunkPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if os.IsExist(err) {
+		MetCacheErrorCount.Inc()
+		Logger.Debugf("chunk %v already exists on the local filesystem, not overwriting", hash)
+	} else {
+		numWritten, err = f.Write(body)
+		defer f.Close()
+		if err != nil {
+			MetCacheErrorCount.Inc()
+			Logger.Errorf("error saving cache file %v: %v", chunkPath, err)
+			return nil, err
+		}
+
+		err = f.Close()
+		if err != nil {
+			MetCacheErrorCount.Inc()
+			Logger.Errorf("error closing cache file %v: %v", chunkPath, err)
+			return nil, err
+		}
+	}
+
+	evicted := c.lru.Add(hash, hash)
+	Logger.Debugf("cached %v bytes for chunk %v, evicted: %v", numWritten, hash, evicted)
+
+	return &cachedChunk{reflectedChunk{body}}, nil
+}
+
+func (c *lruCache) Has(hash string) bool {
+	return c.lru.Contains(hash)
+}
+
+func (c *lruCache) Get(hash string) (ReadableChunk, bool) {
+	if value, ok := c.lru.Get(hash); ok {
+		f, err := c.storage.open(value)
+		if err != nil {
+			MetCacheErrorCount.Inc()
+			Logger.Errorf("chunk %v found in cache but couldn't open the file: %v", hash, err)
+			c.lru.Remove(value)
+			return nil, false
+		}
+		cb, err := initCachedChunk(f)
+		if err != nil {
+			Logger.Errorf("chunk %v found in cache but couldn't read the file: %v", hash, err)
+			return nil, false
+		}
+		defer f.Close()
+		return cb, true
+	}
+
+	Logger.Debugf("cache miss for chunk %v", hash)
+	return nil, false
+}
+
+func (c *lruCache) Remove(hash string) {
+	c.storage.remove(hash)
+	c.lru.Remove(hash)
+}
+
+func (c *lruCache) Size() uint64 {
+	return uint64(c.lru.Len()) * ChunkSize
+}
+
+func (c *lruCache) IsCacheRestored() chan bool {
+	return make(chan bool)
+}

--- a/player/lru_cache.go
+++ b/player/lru_cache.go
@@ -84,20 +84,20 @@ func (c *lruCache) Set(hash string, body []byte) (ReadableChunk, error) {
 
 	f, err := os.OpenFile(chunkPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if os.IsExist(err) {
-		MetCacheErrorCount.Inc()
+		MtrCacheErrorCount.Inc()
 		Logger.Debugf("chunk %v already exists on the local filesystem, not overwriting", hash)
 	} else {
 		numWritten, err = f.Write(body)
 		defer f.Close()
 		if err != nil {
-			MetCacheErrorCount.Inc()
+			MtrCacheErrorCount.Inc()
 			Logger.Errorf("error saving cache file %v: %v", chunkPath, err)
 			return nil, err
 		}
 
 		err = f.Close()
 		if err != nil {
-			MetCacheErrorCount.Inc()
+			MtrCacheErrorCount.Inc()
 			Logger.Errorf("error closing cache file %v: %v", chunkPath, err)
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func (c *lruCache) Get(hash string) (ReadableChunk, bool) {
 	if value, ok := c.lru.Get(hash); ok {
 		f, err := c.storage.open(value)
 		if err != nil {
-			MetCacheErrorCount.Inc()
+			MtrCacheErrorCount.Inc()
 			Logger.Errorf("chunk %v found in cache but couldn't open the file: %v", hash, err)
 			c.lru.Remove(value)
 			return nil, false

--- a/player/lru_cache.go
+++ b/player/lru_cache.go
@@ -44,6 +44,8 @@ func InitLRUCache(opts *LRUCacheOpts) (ChunkCache, error) {
 
 	c := &lruCache{storage, lru}
 
+	Logger.Infof("LRU cache of %vGB initialized at %v", opts.Size/1024/1024/1024, opts.Path)
+
 	go func() {
 		Logger.Infoln("restoring cache in memory...")
 		err := c.reloadCache()
@@ -102,7 +104,7 @@ func (c *lruCache) Set(hash string, body []byte) (ReadableChunk, error) {
 	}
 
 	evicted := c.lru.Add(hash, hash)
-	Logger.Debugf("cached %v bytes for chunk %v, evicted: %v", numWritten, hash, evicted)
+	Logger.Debugf("cached chunk %v, retrieved: %vB, evicted: %v", hash, numWritten, evicted)
 
 	return &cachedChunk{reflectedChunk{body}}, nil
 }

--- a/player/lru_cache_test.go
+++ b/player/lru_cache_test.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/lbryio/lbry.go/v2/stream"
@@ -45,8 +44,9 @@ func TestLRUCacheReloadFolder(t *testing.T) {
 	f.Close()
 
 	c, err := InitLRUCache(&LRUCacheOpts{Path: dir})
-	require.Nil(t, err)
-	time.Sleep(1 * time.Second)
+	require.NoError(t, err)
+	err = c.WaitForRestore()
+	require.NoError(t, err)
 	// the cache doesn't guarantee that when setting an item it's immediately available. so our only option is to wait
 	waitForCache()
 	assert.True(t, c.Has(blobName))

--- a/player/lru_cache_test.go
+++ b/player/lru_cache_test.go
@@ -7,8 +7,10 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/lbryio/lbry.go/v2/stream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,47 +29,46 @@ func TestLRUCache(t *testing.T) {
 	os.Remove(dir)
 }
 
-// func TestLRUCacheReloadFolder(t *testing.T) {
-// 	dir := generateCachePath()
-// 	os.MkdirAll(dir, 0700)
+func TestLRUCacheReloadFolder(t *testing.T) {
+	dir := generateCachePath()
+	os.MkdirAll(dir, 0700)
 
-// 	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 
-// 	blobName := randomString(stream.BlobHashHexLength)
-// 	filesToBeRecached := path.Join(dir, blobName)
-// 	f, err := os.Create(filesToBeRecached)
-// 	require.NoError(t, err)
-// 	n, err := f.Write(make([]byte, stream.MaxBlobSize))
-// 	require.NoError(t, err)
-// 	require.Equal(t, stream.MaxBlobSize, n)
-// 	f.Close()
+	blobName := randomString(stream.BlobHashHexLength)
+	filesToBeRecached := path.Join(dir, blobName)
+	f, err := os.Create(filesToBeRecached)
+	require.NoError(t, err)
+	n, err := f.Write(make([]byte, stream.MaxBlobSize))
+	require.NoError(t, err)
+	require.Equal(t, stream.MaxBlobSize, n)
+	f.Close()
 
-// 	c, err := InitLRUCache(&LRUCacheOpts{Path: dir})
-// 	require.Nil(t, err)
-// 	<-c.IsCacheRestored()
-// 	// the cache doesn't guarantee that when setting an item it's immediately available. so our only option is to wait
-// 	waitForCache()
-// 	isCached := c.Has(blobName)
-// 	assert.True(t, isCached)
-// 	_, err = os.Stat(filesToBeRecached)
-// 	assert.NoError(t, err)
+	c, err := InitLRUCache(&LRUCacheOpts{Path: dir})
+	require.Nil(t, err)
+	time.Sleep(1 * time.Second)
+	// the cache doesn't guarantee that when setting an item it's immediately available. so our only option is to wait
+	waitForCache()
+	assert.True(t, c.Has(blobName))
+	_, err = os.Stat(filesToBeRecached)
+	assert.NoError(t, err)
 
-// 	fileToNotBeRemoved := path.Join(dir, "non_blob_sized_file_name")
-// 	f, err = os.Create(fileToNotBeRemoved)
-// 	require.NoError(t, err)
+	fileToNotBeRemoved := path.Join(dir, "non_blob_sized_file_name")
+	f, err = os.Create(fileToNotBeRemoved)
+	require.NoError(t, err)
 
-// 	// Cleanup
-// 	defer os.Remove(fileToNotBeRemoved)
-// 	defer os.Remove(filesToBeRecached)
+	// Cleanup
+	defer os.Remove(fileToNotBeRemoved)
+	defer os.Remove(filesToBeRecached)
 
-// 	n, err = f.Write(make([]byte, stream.MaxBlobSize/2))
-// 	require.NoError(t, err)
-// 	require.Equal(t, stream.MaxBlobSize/2, n)
-// 	f.Close()
+	n, err = f.Write(make([]byte, stream.MaxBlobSize/2))
+	require.NoError(t, err)
+	require.Equal(t, stream.MaxBlobSize/2, n)
+	f.Close()
 
-// 	_, err = InitLRUCache(&LRUCacheOpts{Path: dir})
-// 	require.Error(t, err)
-// }
+	_, err = InitLRUCache(&LRUCacheOpts{Path: dir})
+	require.Error(t, err)
+}
 
 func TestLRUCacheHas(t *testing.T) {
 	c, err := InitLRUCache(&LRUCacheOpts{Path: generateCachePath()})

--- a/player/metrics.go
+++ b/player/metrics.go
@@ -16,64 +16,64 @@ func InstallMetricsRoutes(r *mux.Router) {
 
 var (
 	nsPlayer       = "player"
-	MetLabelSource = "source"
+	MtrLabelSource = "source"
 
-	MetStreamsRunning = promauto.NewGauge(prometheus.GaugeOpts{
+	MtrStreamsRunning = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: nsPlayer,
 		Subsystem: "streams",
 		Name:      "running",
 		Help:      "Number of streams currently playing",
 	})
-	MetRetrieverSpeed = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	MtrRetrieverSpeed = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: nsPlayer,
 		Subsystem: "retriever",
 		Name:      "speed_mbps",
 		Help:      "Speed of blob/chunk retrieval",
-	}, []string{MetLabelSource})
+	}, []string{MtrLabelSource})
 
-	MetInBytes = promauto.NewCounter(prometheus.CounterOpts{
+	MtrInBytes = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: nsPlayer,
 		Name:      "in_bytes",
 		Help:      "Total number of bytes downloaded",
 	})
-	MetOutBytes = promauto.NewCounter(prometheus.CounterOpts{
+	MtrOutBytes = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: nsPlayer,
 		Name:      "out_bytes",
 		Help:      "Total number of bytes streamed out",
 	})
 
-	MetCacheHitCount = promauto.NewCounter(prometheus.CounterOpts{
+	MtrCacheHitCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: nsPlayer,
 		Subsystem: "cache",
 		Name:      "hit_count",
 		Help:      "Total number of blobs found in the local cache",
 	})
-	MetCacheMissCount = promauto.NewCounter(prometheus.CounterOpts{
+	MtrCacheMissCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: nsPlayer,
 		Subsystem: "cache",
 		Name:      "miss_count",
 		Help:      "Total number of blobs that were not in the local cache",
 	})
-	MetCacheErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+	MtrCacheErrorCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: nsPlayer,
 		Subsystem: "cache",
 		Name:      "error_count",
 		Help:      "Total number of errors retrieving blobs from the local cache",
 	})
 
-	MetCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
+	MtrCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: nsPlayer,
 		Subsystem: "cache",
 		Name:      "size",
 		Help:      "Current size of cache",
 	})
-	MetCacheDroppedCount = promauto.NewGauge(prometheus.GaugeOpts{
+	MtrCacheDroppedCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: nsPlayer,
 		Subsystem: "cache",
 		Name:      "dropped_count",
 		Help:      "Total number of blobs dropped at the admission time",
 	})
-	MetCacheRejectedCount = promauto.NewGauge(prometheus.GaugeOpts{
+	MtrCacheRejectedCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: nsPlayer,
 		Subsystem: "cache",
 		Name:      "rejected_count",

--- a/player/player.go
+++ b/player/player.go
@@ -137,8 +137,8 @@ func (p *Player) getBlobStore() store.BlobStore {
 
 // Play delivers requested URI onto the supplied http.ResponseWriter.
 func (p *Player) Play(s *Stream, w http.ResponseWriter, r *http.Request) error {
-	MetStreamsRunning.Inc()
-	defer MetStreamsRunning.Dec()
+	MtrStreamsRunning.Inc()
+	defer MtrStreamsRunning.Dec()
 	ServeStream(w, r, s)
 	return nil
 }
@@ -344,13 +344,13 @@ func (b *chunkGetter) Get(n int) (ReadableChunk, error) {
 
 	if cacheHit {
 		rate := float64(cChunk.Size()) / (1024 * 1024) / timerCache.Duration * 8
-		MetRetrieverSpeed.With(map[string]string{MetLabelSource: RetrieverSourceL2Cache}).Set(rate)
-		MetCacheHitCount.Inc()
+		MtrRetrieverSpeed.With(map[string]string{MtrLabelSource: RetrieverSourceL2Cache}).Set(rate)
+		MtrCacheHitCount.Inc()
 		b.saveToHotCache(n, cChunk)
 		return cChunk, nil
 	}
 
-	MetCacheMissCount.Inc()
+	MtrCacheMissCount.Inc()
 	timerReflector := TimerStart()
 	rChunk, err = b.getChunkFromReflector(hash, b.sdBlob.Key, bi.IV)
 	if err != nil {
@@ -359,7 +359,7 @@ func (b *chunkGetter) Get(n int) (ReadableChunk, error) {
 	timerReflector.Done()
 
 	rate := float64(rChunk.Size()) / (1024 * 1024) / timerReflector.Duration * 8
-	MetRetrieverSpeed.With(map[string]string{MetLabelSource: RetrieverSourceReflector}).Set(rate)
+	MtrRetrieverSpeed.With(map[string]string{MtrLabelSource: RetrieverSourceReflector}).Set(rate)
 
 	b.saveToHotCache(n, rChunk)
 	go func() {
@@ -449,7 +449,7 @@ func (b *chunkGetter) getChunkFromReflector(hash string, key, iv []byte) (*refle
 		return nil, err
 	}
 
-	MetInBytes.Add(float64(len(blob)))
+	MtrInBytes.Add(float64(len(blob)))
 
 	body, err := stream.DecryptBlob(blob, key, iv)
 	if err != nil {

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,11 +38,6 @@ func randomString(n int) string {
 		b[i] = letter[rand.Intn(len(letter))]
 	}
 	return string(b)
-}
-
-func TestNewPlayer(t *testing.T) {
-	p := NewPlayer(&Opts{EnableL2Cache: true})
-	assert.IsType(t, p.localCache, &fsCache{})
 }
 
 func TestPlayerResolveStream(t *testing.T) {
@@ -158,7 +155,9 @@ func TestStreamRead(t *testing.T) {
 }
 
 func TestStreamReadHotCache(t *testing.T) {
-	p := NewPlayer(&Opts{EnableL2Cache: true, EnablePrefetch: false})
+	cache, err := InitLRUCache(&LRUCacheOpts{Path: path.Join(os.TempDir(), "blob_cache")})
+	require.NoError(t, err)
+	p := NewPlayer(&Opts{LocalCache: cache, EnablePrefetch: false})
 
 	s, err := p.ResolveStream(streamURL)
 	require.NoError(t, err)


### PR DESCRIPTION
The motivation for this is how TinyLFU strategy we are using now behaves when the cache is full:

1. TinyLFU may refuse to admit a blob unless it’s been "popular" enough
2. LRU will admit and evict the oldest item.