### PR TITLE
Fixed wrong port for reflector server in dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       com.centurylinklabs.watchtower.enable: true
     ports:
     - "8080:8080"
-    entrypoint: /app/lbrytv_player --cache_size=100GB --lbrynet=http://lbrynet:5279 --reflector=refractor.lbry.com:5567 --bind=0.0.0.0:8080 --profile
+    entrypoint: /app/lbrytv_player --cache_size=100GB --lbrynet=http://lbrynet:5279 --reflector=refractor.lbry.com:5568 --bind=0.0.0.0:8080 --profile
     depends_on:
     - lbrynet
 


### PR DESCRIPTION
Otherwise in old setup you get error:
```retrieval error: Get https://refractor.lbry.com:5567/get/ab49509ca2826aaa3601b823c33c8e90c55a00b524b4dadb68530a3239310d2a6c57b64ddc7c95e4321a47729308f189: NO_ERROR: Handshake did not complete in time"}```