### PR TITLE
Escape filename in Content-Disposition header

### DIFF
--- a/player/http_handlers.go
+++ b/player/http_handlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -85,7 +86,7 @@ func writeHeaders(w http.ResponseWriter, r *http.Request, s *Stream) {
 	header.Set("X-Powered-By", playerName)
 	header.Set("Access-Control-Expose-Headers", "X-Powered-By")
 	if r.URL.Query().Get(paramDownload) != "" {
-		header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%v\"", s.Filename()))
+		header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q; filename*=UTF-8''%v", strings.ReplaceAll(s.Filename(), `"`, ``), url.PathEscape(s.Filename())))
 	}
 }
 

--- a/player/http_handlers.go
+++ b/player/http_handlers.go
@@ -85,7 +85,7 @@ func writeHeaders(w http.ResponseWriter, r *http.Request, s *Stream) {
 	header.Set("X-Powered-By", playerName)
 	header.Set("Access-Control-Expose-Headers", "X-Powered-By")
 	if r.URL.Query().Get(paramDownload) != "" {
-		header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%v", s.Filename()))
+		header.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%v\"", s.Filename()))
 	}
 }
 

--- a/player/http_handlers_test.go
+++ b/player/http_handlers_test.go
@@ -152,14 +152,14 @@ func TestHandleOutOfBounds(t *testing.T) {
 func TestHandleDownloadableFile(t *testing.T) {
 	r := makeRequest(t, nil, http.MethodGet, "/content/claims/scalable-test2/0a15a743ac078a83a02cc086fbb8b566e912b7c5/stream?download=1", nil)
 	assert.Equal(t, http.StatusOK, r.StatusCode)
-	assert.Equal(t, "attachment; filename=861382668_228248581_tenor.gif", r.Header.Get("Content-Disposition"))
+	assert.Equal(t, `attachment; filename="861382668_228248581_tenor.gif"; filename*=UTF-8''861382668_228248581_tenor.gif`, r.Header.Get("Content-Disposition"))
 	assert.Equal(t, "8722934", r.Header.Get("Content-Length"))
 }
 
 func TestHandleDownloadableFileHead(t *testing.T) {
 	r := makeRequest(t, nil, http.MethodHead, "/content/claims/scalable-test2/0a15a743ac078a83a02cc086fbb8b566e912b7c5/stream?download=1", nil)
 	assert.Equal(t, http.StatusOK, r.StatusCode)
-	assert.Equal(t, "attachment; filename=861382668_228248581_tenor.gif", r.Header.Get("Content-Disposition"))
+	assert.Equal(t, `attachment; filename="861382668_228248581_tenor.gif"; filename*=UTF-8''861382668_228248581_tenor.gif`, r.Header.Get("Content-Disposition"))
 	assert.Equal(t, "8722934", r.Header.Get("Content-Length"))
 }
 


### PR DESCRIPTION
The `filename` directive should be quoted, as described here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

This should fix https://github.com/lbryio/lbrytv/issues/232.

Chrome currently handles an unquoted `filename` directive, although Firefox has issues with it and ends the filename where the first space character is.

I _think_ this may also fix https://github.com/lbryio/lbry-desktop/issues/4763, which is a problem that exists even on Chrome. Here the `,` character puts an end to the filename in Chrome.

> content-disposition: attachment; filename=Osprey - New Vanguard 154 - British Battleships 1939-45 Part 1, Queen Elizabeth and Royal Soverign Classes.pdf

I am sure there is a better/proper way to escape filenames. There's a lot of discussion on StackOverflow regarding this topic, but I think this simple change should improve the vast majority of the current issues. https://stackoverflow.com/questions/7967079/special-characters-in-content-disposition-filename